### PR TITLE
Only need to restart the web container, not rebuild

### DIFF
--- a/mastodon_install.md
+++ b/mastodon_install.md
@@ -123,8 +123,8 @@ Since we are using docker for this, building mastodon is actually pretty straigh
 7. ```docker-compose run --rm web rails assets:precompile```
 > Precompile the asset cache for SPEED.
 
-8. ```docker-compose build```
-> Needed again after the precompile command always.
+8. ```docker-compose restart web```
+> Needed again after the precompile command always, to pick up the new bundles.
 
 <a name="InstallNginx"></a>
 ## Installing nginx to proxy to mastodon.


### PR DESCRIPTION
The assets precompile writes web bundles into public/assets/, which is mounted into the web container as a volume. So the new files already exist inside the container once you generate them, but Mastodon needs to be restarted to pick them up. The quickest way to do this is just to issue a restart with docker-compose.